### PR TITLE
Python 3.12 지원

### DIFF
--- a/koreanize_matplotlib/koreanize_matplotlib.py
+++ b/koreanize_matplotlib/koreanize_matplotlib.py
@@ -2,7 +2,7 @@ import os
 
 import matplotlib
 from matplotlib import font_manager
-from distutils.version import LooseVersion
+from packaging.version import Version, parse
 
 FONTS_DIR = 'fonts'
 FONT_NAME = "NanumGothic"
@@ -13,7 +13,7 @@ def koreanize():
     font_dir_path = get_font_path()
     font_dirs = [font_dir_path]
     font_files = font_manager.findSystemFonts(fontpaths=font_dirs)
-    is_support_createFontList = LooseVersion(matplotlib.__version__) < '3.2'
+    is_support_createFontList = Version(matplotlib.__version__) < parse('3.2')
     if is_support_createFontList:
         font_list = font_manager.createFontList(font_files)
         font_manager.fontManager.ttflist.extend(font_list)

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
 # encoding: utf8
-from distutils.core import setup
-from setuptools import find_packages
+from setuptools import find_packages, setup
 from os import path
 
 with open(path.join(path.abspath(path.dirname(__file__)), 'README.md'), encoding='utf-8') as f:


### PR DESCRIPTION
안녕하세요.

먼저, 좋은 라이브러리를 공개해주셔서 감사드립니다. 

이 PR은 Python 3.12에서 distutils이 더 이상 지원이 되지 않고 있습니다. 그래서 distutils을 마이그레이션 한 결과를 PR로 보내봅니다. 마이그레이션은 [Porting from Distutils](https://setuptools.pypa.io/en/latest/deprecated/distutils-legacy.html)을 참고하여 진행하였습니다.

해당 라이브러리에 조그마한 도움이 되었기를 기대합니다.

감사합니다.